### PR TITLE
chore(): `business-rules` extensions and enhancements examples

### DIFF
--- a/business_rules/engine.py
+++ b/business_rules/engine.py
@@ -1,10 +1,7 @@
 from .fields import FIELD_NO_INPUT
 
-def run_all(rule_list,
-            defined_variables,
-            defined_actions,
-            stop_on_first_trigger=False):
 
+def run_all(rule_list, defined_variables, defined_actions, stop_on_first_trigger=False):
     rule_was_triggered = False
     for rule in rule_list:
         result = run(rule, defined_variables, defined_actions)
@@ -14,8 +11,9 @@ def run_all(rule_list,
                 return True
     return rule_was_triggered
 
+
 def run(rule, defined_variables, defined_actions):
-    conditions, actions = rule['conditions'], rule['actions']
+    conditions, actions = rule["conditions"], rule["actions"]
     rule_triggered = check_conditions_recursively(conditions, defined_variables)
     if rule_triggered:
         do_actions(actions, defined_actions)
@@ -25,72 +23,115 @@ def run(rule, defined_variables, defined_actions):
 
 def check_conditions_recursively(conditions, defined_variables):
     keys = list(conditions.keys())
-    if keys == ['all']:
-        assert len(conditions['all']) >= 1
-        for condition in conditions['all']:
+    if keys == ["not"]:
+        return not check_conditions_recursively(conditions["not"], defined_variables)
+
+    if keys == ["all"]:
+        if len(conditions["all"]) < 1:
+            raise ValueError("'all' conditions must have at least one child condition")
+        for condition in conditions["all"]:
             if not check_conditions_recursively(condition, defined_variables):
                 return False
         return True
 
-    elif keys == ['any']:
-        assert len(conditions['any']) >= 1
-        for condition in conditions['any']:
+    elif keys == ["any"]:
+        if len(conditions["any"]) < 1:
+            raise ValueError("'any' conditions must have at least one child condition")
+        for condition in conditions["any"]:
             if check_conditions_recursively(condition, defined_variables):
                 return True
         return False
 
     else:
-        # help prevent errors - any and all can only be in the condition dict
+        # help prevent errors - not, any, and all can only be in the condition dict
         # if they're the only item
-        assert not ('any' in keys or 'all' in keys)
+        if "not" in keys or "any" in keys or "all" in keys:
+            raise ValueError(
+                "Only one of 'not', 'any', or 'all' can be at the same level in the conditions dict"
+            )
         return check_condition(conditions, defined_variables)
 
+
 def check_condition(condition, defined_variables):
-    """ Checks a single rule condition - the condition will be made up of
+    """Checks a single rule condition - the condition will be made up of
     variables, values, and the comparison operator. The defined_variables
     object must have a variable defined for any variables in this condition.
     """
-    name, op, value = condition['name'], condition['operator'], condition['value']
+    name, op, value, other_variable_name = (
+        condition["name"],
+        condition["operator"],
+        condition.get("value"),
+        condition.get("other_variable_name"),
+    )
     operator_type = _get_variable_value(defined_variables, name)
-    return _do_operator_comparison(operator_type, op, value)
+    if other_variable_name is not None:
+        other_operator_type = _get_variable_value(
+            defined_variables, other_variable_name
+        )
+        if type(other_operator_type) is not type(operator_type):
+            raise ValueError(
+                "Both variables in a dual variable comparison must be of the same type"
+            )
+        return _do_operator_comparison(operator_type, op, other_operator_type.value)
+    elif value is not None:
+        return _do_operator_comparison(operator_type, op, value)
+    else:
+        raise ValueError("Condition must have a 'value' or 'other_variable_name' key")
+
 
 def _get_variable_value(defined_variables, name):
-    """ Call the function provided on the defined_variables object with the
+    """Call the function provided on the defined_variables object with the
     given name (raise exception if that doesn't exist) and casts it to the
     specified type.
 
     Returns an instance of operators.BaseType
     """
+
     def fallback(*args, **kwargs):
-        raise AssertionError("Variable {0} is not defined in class {1}".format(
-                name, defined_variables.__class__.__name__))
+        raise AssertionError(
+            "Variable {0} is not defined in class {1}".format(
+                name, defined_variables.__class__.__name__
+            )
+        )
+
     method = getattr(defined_variables, name, fallback)
     val = method()
     return method.field_type(val)
 
+
 def _do_operator_comparison(operator_type, operator_name, comparison_value):
-    """ Finds the method on the given operator_type and compares it to the
+    """Finds the method on the given operator_type and compares it to the
     given comparison_value.
 
     operator_type should be an instance of operators.BaseType
     comparison_value is whatever python type to compare to
     returns a bool
     """
+
     def fallback(*args, **kwargs):
-        raise AssertionError("Operator {0} does not exist for type {1}".format(
-            operator_name, operator_type.__class__.__name__))
+        raise AssertionError(
+            "Operator {0} does not exist for type {1}".format(
+                operator_name, operator_type.__class__.__name__
+            )
+        )
+
     method = getattr(operator_type, operator_name, fallback)
-    if getattr(method, 'input_type', '') == FIELD_NO_INPUT:
+    if getattr(method, "input_type", "") == FIELD_NO_INPUT:
         return method()
     return method(comparison_value)
 
 
 def do_actions(actions, defined_actions):
     for action in actions:
-        method_name = action['name']
+        method_name = action["name"]
+
         def fallback(*args, **kwargs):
-            raise AssertionError("Action {0} is not defined in class {1}"\
-                    .format(method_name, defined_actions.__class__.__name__))
-        params = action.get('params') or {}
+            raise AssertionError(
+                "Action {0} is not defined in class {1}".format(
+                    method_name, defined_actions.__class__.__name__
+                )
+            )
+
+        params = action.get("params") or {}
         method = getattr(defined_actions, method_name, fallback)
         method(**params)

--- a/business_rules/fields.py
+++ b/business_rules/fields.py
@@ -1,5 +1,6 @@
-FIELD_TEXT = 'text'
-FIELD_NUMERIC = 'numeric'
-FIELD_NO_INPUT = 'none'
-FIELD_SELECT = 'select'
-FIELD_SELECT_MULTIPLE = 'select_multiple'
+FIELD_TEXT = "text"
+FIELD_NUMERIC = "numeric"
+FIELD_NO_INPUT = "none"
+FIELD_SELECT = "select"
+FIELD_SELECT_MULTIPLE = "select_multiple"
+FIELD_DATETIME = "datetime"

--- a/business_rules/operators.py
+++ b/business_rules/operators.py
@@ -1,70 +1,79 @@
 import inspect
 import re
+from datetime import date, datetime
 from functools import wraps
 from six import string_types, integer_types
 
-from .fields import (FIELD_TEXT, FIELD_NUMERIC, FIELD_NO_INPUT,
-                     FIELD_SELECT, FIELD_SELECT_MULTIPLE)
+from .fields import (
+    FIELD_TEXT,
+    FIELD_NUMERIC,
+    FIELD_NO_INPUT,
+    FIELD_SELECT,
+    FIELD_SELECT_MULTIPLE,
+    FIELD_DATETIME,
+)
 from .utils import fn_name_to_pretty_label, float_to_decimal
-from decimal import Decimal, Inexact, Context
+from decimal import Decimal
+
 
 class BaseType(object):
     def __init__(self, value):
         self.value = self._assert_valid_value_and_cast(value)
 
     def _assert_valid_value_and_cast(self, value):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     @classmethod
     def get_all_operators(cls):
         methods = inspect.getmembers(cls)
-        return [{'name': m[0],
-                 'label': m[1].label,
-                 'input_type': m[1].input_type}
-                for m in methods if getattr(m[1], 'is_operator', False)]
+        return [
+            {"name": m[0], "label": m[1].label, "input_type": m[1].input_type}
+            for m in methods
+            if getattr(m[1], "is_operator", False)
+        ]
 
 
 def export_type(cls):
-    """ Decorator to expose the given class to business_rules.export_rule_data. """
+    """Decorator to expose the given class to business_rules.export_rule_data."""
     cls.export_in_rule_data = True
     return cls
 
 
-def type_operator(input_type, label=None,
-                  assert_type_for_arguments=True):
-    """ Decorator to make a function into a type operator.
+def type_operator(input_type, label=None, assert_type_for_arguments=True):
+    """Decorator to make a function into a type operator.
 
     - assert_type_for_arguments - if True this patches the operator function
       so that arguments passed to it will have _assert_valid_value_and_cast
       called on them to make type errors explicit.
     """
+
     def wrapper(func):
         func.is_operator = True
-        func.label = label \
-            or fn_name_to_pretty_label(func.__name__)
+        func.label = label or fn_name_to_pretty_label(func.__name__)
         func.input_type = input_type
 
         @wraps(func)
         def inner(self, *args, **kwargs):
             if assert_type_for_arguments:
                 args = [self._assert_valid_value_and_cast(arg) for arg in args]
-                kwargs = dict((k, self._assert_valid_value_and_cast(v))
-                              for k, v in kwargs.items())
+                kwargs = dict(
+                    (k, self._assert_valid_value_and_cast(v)) for k, v in kwargs.items()
+                )
             return func(self, *args, **kwargs)
+
         return inner
+
     return wrapper
 
 
 @export_type
 class StringType(BaseType):
-
     name = "string"
 
     def _assert_valid_value_and_cast(self, value):
         value = value or ""
         if not isinstance(value, string_types):
-            raise AssertionError("{0} is not a valid string type.".
-                                 format(value))
+            raise AssertionError("{0} is not a valid string type.".format(value))
         return value
 
     @type_operator(FIELD_TEXT)
@@ -98,7 +107,7 @@ class StringType(BaseType):
 
 @export_type
 class NumericType(BaseType):
-    EPSILON = Decimal('0.000001')
+    EPSILON = Decimal("0.000001")
 
     name = "numeric"
 
@@ -112,8 +121,7 @@ class NumericType(BaseType):
         if isinstance(value, Decimal):
             return value
         else:
-            raise AssertionError("{0} is not a valid numeric type.".
-                                 format(value))
+            raise AssertionError("{0} is not a valid numeric type.".format(value))
 
     @type_operator(FIELD_NUMERIC)
     def equal_to(self, other_numeric):
@@ -138,13 +146,11 @@ class NumericType(BaseType):
 
 @export_type
 class BooleanType(BaseType):
-
     name = "boolean"
 
     def _assert_valid_value_and_cast(self, value):
-        if type(value) != bool:
-            raise AssertionError("{0} is not a valid boolean type".
-                                 format(value))
+        if type(value) is not bool:
+            raise AssertionError("{0} is not a valid boolean type".format(value))
         return value
 
     @type_operator(FIELD_NO_INPUT)
@@ -155,22 +161,22 @@ class BooleanType(BaseType):
     def is_false(self):
         return not self.value
 
+
 @export_type
 class SelectType(BaseType):
-
     name = "select"
 
     def _assert_valid_value_and_cast(self, value):
-        if not hasattr(value, '__iter__'):
-            raise AssertionError("{0} is not a valid select type".
-                                 format(value))
+        if not hasattr(value, "__iter__"):
+            raise AssertionError("{0} is not a valid select type".format(value))
         return value
 
     @staticmethod
     def _case_insensitive_equal_to(value_from_list, other_value):
-        if isinstance(value_from_list, string_types) and \
-                isinstance(other_value, string_types):
-                    return value_from_list.lower() == other_value.lower()
+        if isinstance(value_from_list, string_types) and isinstance(
+            other_value, string_types
+        ):
+            return value_from_list.lower() == other_value.lower()
         else:
             return value_from_list == other_value
 
@@ -191,13 +197,13 @@ class SelectType(BaseType):
 
 @export_type
 class SelectMultipleType(BaseType):
-
     name = "select_multiple"
 
     def _assert_valid_value_and_cast(self, value):
-        if not hasattr(value, '__iter__'):
-            raise AssertionError("{0} is not a valid select multiple type".
-                                 format(value))
+        if not hasattr(value, "__iter__"):
+            raise AssertionError(
+                "{0} is not a valid select multiple type".format(value)
+            )
         return value
 
     @type_operator(FIELD_SELECT_MULTIPLE)
@@ -235,3 +241,73 @@ class SelectMultipleType(BaseType):
     @type_operator(FIELD_SELECT_MULTIPLE)
     def shares_no_elements_with(self, other_value):
         return not self.shares_at_least_one_element_with(other_value)
+
+
+@export_type
+class DateTimeType(BaseType):
+    name = "datetime"
+    DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S"
+    DATE_FORMAT = "%Y-%m-%d"
+
+    def _assert_valid_value_and_cast(self, value):
+        """
+        Parse string with formats '%Y-%m-%dT%H:%M:%S' or '%Y-%m-%d' into
+        datetime.datetime instance.
+
+        :param value:
+        :return:
+        """
+        if isinstance(value, datetime):
+            return value
+
+        if isinstance(value, date):
+            return datetime(value.year, value.month, value.day)
+
+        try:
+            return datetime.strptime(value, self.DATETIME_FORMAT)
+        except (ValueError, TypeError):
+            pass
+
+        try:
+            return datetime.strptime(value, self.DATE_FORMAT)
+        except (ValueError, TypeError):
+            raise AssertionError("{0} is not a valid datetime type.".format(value))
+
+    def _set_timezone_if_different(self, variable_datetime, condition_value_datetime):
+        # type: (datetime, datetime) -> datetime
+        if variable_datetime.tzinfo is None:
+            if condition_value_datetime.tzinfo is None:
+                return condition_value_datetime
+            else:
+                return condition_value_datetime.replace(tzinfo=None)
+
+        return condition_value_datetime.replace(tzinfo=variable_datetime.tzinfo)
+
+    @type_operator(FIELD_DATETIME)
+    def equal_to(self, other_datetime):
+        # type: (datetime) -> bool
+        other_datetime = self._set_timezone_if_different(self.value, other_datetime)
+
+        return self.value == other_datetime
+
+    @type_operator(FIELD_DATETIME)
+    def after_than(self, other_datetime):
+        # type: (datetime) -> bool
+        other_datetime = self._set_timezone_if_different(self.value, other_datetime)
+
+        return self.value > other_datetime
+
+    @type_operator(FIELD_DATETIME)
+    def after_than_or_equal_to(self, other_datetime):
+        return self.after_than(other_datetime) or self.equal_to(other_datetime)
+
+    @type_operator(FIELD_DATETIME)
+    def before_than(self, other_datetime):
+        # type: (datetime) -> bool
+        other_datetime = self._set_timezone_if_different(self.value, other_datetime)
+
+        return self.value < other_datetime
+
+    @type_operator(FIELD_DATETIME)
+    def before_than_or_equal_to(self, other_datetime):
+        return self.before_than(other_datetime) or self.equal_to(other_datetime)

--- a/tests/test_engine_logic.py
+++ b/tests/test_engine_logic.py
@@ -1,195 +1,298 @@
+from unittest.mock import patch, MagicMock
+
+import pytest
+
 from business_rules import engine
 from business_rules.variables import BaseVariables
-from business_rules.operators import StringType
+from business_rules.operators import BaseType, StringType
 from business_rules.actions import BaseActions
 
-from mock import patch, MagicMock
-from unittest import TestCase
+
+@patch.object(engine, "run")
+def test_run_all_some_rule_triggered(_mock_engine_run: MagicMock) -> None:
+    """By default, does not stop on first triggered rule. Returns True if
+    any rule was triggered, otherwise False
+    """
+    rule1 = {"conditions": "condition1", "actions": "action name 1"}
+    rule2 = {"conditions": "condition2", "actions": "action name 2"}
+    variables = BaseVariables()
+    actions = BaseActions()
+
+    def return_action1(rule, *args, **kwargs):
+        return rule["actions"] == "action name 1"
+
+    engine.run.side_effect = return_action1
+
+    result = engine.run_all([rule1, rule2], variables, actions)
+    assert result is True
+    assert engine.run.call_count == 2
+
+    # switch order and try again
+    engine.run.reset_mock()
+
+    result = engine.run_all([rule2, rule1], variables, actions)
+    assert result is True
+    assert engine.run.call_count == 2
 
 
-class EngineTests(TestCase):
+@patch.object(engine, "run", return_value=True)
+def test_run_all_stop_on_first(_mock_engine_run: MagicMock) -> None:
+    rule1 = {"conditions": "condition1", "actions": "action name 1"}
+    rule2 = {"conditions": "condition2", "actions": "action name 2"}
+    variables = BaseVariables()
+    actions = BaseActions()
 
-    ###
-    ### Run
-    ###
-
-    @patch.object(engine, 'run')
-    def test_run_all_some_rule_triggered(self, *args):
-        """ By default, does not stop on first triggered rule. Returns True if
-        any rule was triggered, otherwise False
-        """
-        rule1 = {'conditions': 'condition1', 'actions': 'action name 1'}
-        rule2 = {'conditions': 'condition2', 'actions': 'action name 2'}
-        variables = BaseVariables()
-        actions = BaseActions()
-
-        def return_action1(rule, *args, **kwargs):
-            return rule['actions'] == 'action name 1'
-        engine.run.side_effect = return_action1
-
-        result = engine.run_all([rule1, rule2], variables, actions)
-        self.assertTrue(result)
-        self.assertEqual(engine.run.call_count, 2)
-
-        # switch order and try again
-        engine.run.reset_mock()
-
-        result = engine.run_all([rule2, rule1], variables, actions)
-        self.assertTrue(result)
-        self.assertEqual(engine.run.call_count, 2)
-
-    @patch.object(engine, 'run', return_value=True)
-    def test_run_all_stop_on_first(self, *args):
-        rule1 = {'conditions': 'condition1', 'actions': 'action name 1'}
-        rule2 = {'conditions': 'condition2', 'actions': 'action name 2'}
-        variables = BaseVariables()
-        actions = BaseActions()
-
-        result = engine.run_all([rule1, rule2], variables, actions,
-                stop_on_first_trigger=True)
-        self.assertEqual(result, True)
-        self.assertEqual(engine.run.call_count, 1)
-        engine.run.assert_called_once_with(rule1, variables, actions)
-
-    @patch.object(engine, 'check_conditions_recursively', return_value=True)
-    @patch.object(engine, 'do_actions')
-    def test_run_that_triggers_rule(self, *args):
-        rule = {'conditions': 'blah', 'actions': 'blah2'}
-        variables = BaseVariables()
-        actions = BaseActions()
-
-        result = engine.run(rule, variables, actions)
-        self.assertEqual(result, True)
-        engine.check_conditions_recursively.assert_called_once_with(
-                rule['conditions'], variables)
-        engine.do_actions.assert_called_once_with(rule['actions'], actions)
+    result = engine.run_all(
+        [rule1, rule2], variables, actions, stop_on_first_trigger=True
+    )
+    assert result is True
+    assert engine.run.call_count == 1
+    engine.run.assert_called_once_with(rule1, variables, actions)
 
 
-    @patch.object(engine, 'check_conditions_recursively', return_value=False)
-    @patch.object(engine, 'do_actions')
-    def test_run_that_doesnt_trigger_rule(self, *args):
-        rule = {'conditions': 'blah', 'actions': 'blah2'}
-        variables = BaseVariables()
-        actions = BaseActions()
+@patch.object(engine, "check_conditions_recursively", return_value=True)
+@patch.object(engine, "do_actions")
+def test_run_that_triggers_rule(
+    _mock_do_actions: MagicMock, _mock_check_conditions_recursively: MagicMock
+) -> None:
+    rule = {"conditions": "blah", "actions": "blah2"}
+    variables = BaseVariables()
+    actions = BaseActions()
 
-        result = engine.run(rule, variables, actions)
-        self.assertEqual(result, False)
-        engine.check_conditions_recursively.assert_called_once_with(
-                rule['conditions'], variables)
-        self.assertEqual(engine.do_actions.call_count, 0)
+    result = engine.run(rule, variables, actions)
+    assert result is True
+    engine.check_conditions_recursively.assert_called_once_with(
+        rule["conditions"], variables
+    )
+    engine.do_actions.assert_called_once_with(rule["actions"], actions)
 
 
-    @patch.object(engine, 'check_condition', return_value=True)
-    def test_check_all_conditions_with_all_true(self, *args):
-        conditions = {'all': [{'thing1': ''}, {'thing2': ''}]}
-        variables = BaseVariables()
+@patch.object(engine, "check_conditions_recursively", return_value=False)
+@patch.object(engine, "do_actions")
+def test_run_that_doesnt_trigger_rule(
+    _mock_do_actions: MagicMock, _mock_check_conditions_recursively: MagicMock
+) -> None:
+    """
+    DOCUMENT ME.
+    """
+    rule = {"conditions": "blah", "actions": "blah2"}
+    variables = BaseVariables()
+    actions = BaseActions()
+    # set up
+    result = engine.run(rule, variables, actions)
+    assert result is False
+    engine.check_conditions_recursively.assert_called_once_with(
+        rule["conditions"], variables
+    )
+    assert engine.do_actions.call_count == 0
 
+
+def test_do_actions() -> None:
+    actions = [
+        {"name": "action1"},
+        {"name": "action2", "params": {"param1": "foo", "param2": 10}},
+    ]
+    defined_actions = BaseActions()
+    defined_actions.action1 = MagicMock()
+    defined_actions.action2 = MagicMock()
+
+    engine.do_actions(actions, defined_actions)
+
+    defined_actions.action1.assert_called_once_with()
+    defined_actions.action2.assert_called_once_with(param1="foo", param2=10)
+
+
+def test_check_operator_comparison() -> None:
+    string_type = StringType("yo yo")
+    with patch.object(string_type, "contains", return_value=True):
+        result = engine._do_operator_comparison(string_type, "contains", "its mocked")
+        assert result is True
+        string_type.contains.assert_called_once_with("its mocked")
+
+
+@patch.object(engine, "check_condition", return_value=True)
+def test_check_all_conditions_with_all_true(_mock_check_condition: MagicMock) -> None:
+    # set up
+    conditions = {"all": [{"thing1": ""}, {"thing2": ""}]}
+    variables = BaseVariables()
+    # test
+    result = engine.check_conditions_recursively(conditions, variables)
+    assert result is True
+    # assert call count and most recent call are as expected
+    assert engine.check_condition.call_count == 2
+    engine.check_condition.assert_called_with({"thing2": ""}, variables)
+
+
+@patch.object(engine, "check_condition", return_value=False)
+def test_check_all_conditions_with_all_false(_mock_check_condition: MagicMock) -> None:
+    # set up
+    conditions = {"all": [{"thing1": ""}, {"thing2": ""}]}
+    variables = BaseVariables()
+    # test
+    result = engine.check_conditions_recursively(conditions, variables)
+    assert result is False
+    engine.check_condition.assert_called_once_with({"thing1": ""}, variables)
+
+
+def test_check_all_and_any_together() -> None:
+    conditions = {"any": [], "all": []}
+    variables = BaseVariables()
+    with pytest.raises(
+        ValueError,
+        match="Only one of 'not', 'any', or 'all' can be at the same level in the conditions dict",
+    ):
+        engine.check_conditions_recursively(conditions, variables)
+
+
+def test_check_all_conditions_with_no_items_fails() -> None:
+    with pytest.raises(
+        ValueError, match="'all' conditions must have at least one child condition"
+    ):
+        engine.check_conditions_recursively({"all": []}, BaseVariables())
+
+
+@patch.object(engine, "check_condition", return_value=True)
+def test_check_any_conditions_with_all_true(_mock_check_condition: MagicMock) -> None:
+    conditions = {"any": [{"thing1": ""}, {"thing2": ""}]}
+    variables = BaseVariables()
+
+    result = engine.check_conditions_recursively(conditions, variables)
+    assert result is True
+    engine.check_condition.assert_called_once_with({"thing1": ""}, variables)
+
+
+@patch.object(engine, "check_condition", return_value=False)
+def test_check_any_conditions_with_all_false(_mock_check_condition: MagicMock) -> None:
+    conditions = {"any": [{"thing1": ""}, {"thing2": ""}]}
+    variables = BaseVariables()
+
+    result = engine.check_conditions_recursively(conditions, variables)
+    assert result is False
+    # assert call count and most recent call are as expected
+    assert engine.check_condition.call_count == 2
+    engine.check_condition.assert_called_with({"thing2": ""}, variables)
+
+
+def test_check_any_condition_with_no_items_fails() -> None:
+    with pytest.raises(
+        ValueError, match="'any' conditions must have at least one child condition"
+    ):
+        engine.check_conditions_recursively({"any": []}, BaseVariables())
+
+
+@patch.object(engine, "check_condition")
+def test_nested_all_and_any(_mock_check_condition: MagicMock) -> None:
+    # test
+    conditions = {"all": [{"any": [{"name": 1}, {"name": 2}]}, {"name": 3}]}
+    bv = BaseVariables()
+
+    def side_effect(condition, _):
+        return condition["name"] in [2, 3]
+
+    engine.check_condition.side_effect = side_effect
+    # test
+    engine.check_conditions_recursively(conditions, bv)
+    assert engine.check_condition.call_count == 3
+    engine.check_condition.assert_any_call({"name": 1}, bv)
+    engine.check_condition.assert_any_call({"name": 2}, bv)
+    engine.check_condition.assert_any_call({"name": 3}, bv)
+
+
+@pytest.mark.parametrize("other_key", ["all", "any"])
+def test_check_not_with_all_any(other_key: str) -> None:
+    """
+    DOCUMENT ME.
+    """
+    conditions = {"not": [], other_key: []}
+    variables = BaseVariables()
+    with pytest.raises(
+        ValueError,
+        match="Only one of 'not', 'any', or 'all' can be at the same level in the conditions dict",
+    ):
+        engine.check_conditions_recursively(conditions, variables)
+
+
+@pytest.mark.parametrize(
+    "check_condition_result, expected_result", [(True, False), (False, True)]
+)
+def test_check_not_negates_result(
+    check_condition_result: bool, expected_result: bool
+) -> None:
+    """
+    DOCUMENT ME.
+    """
+    conditions = {"not": {"thing1": ""}}
+    variables = BaseVariables()
+
+    with patch.object(
+        engine, "check_condition", return_value=check_condition_result
+    ) as mock_check_condition:
         result = engine.check_conditions_recursively(conditions, variables)
-        self.assertEqual(result, True)
-        # assert call count and most recent call are as expected
-        self.assertEqual(engine.check_condition.call_count, 2)
-        engine.check_condition.assert_called_with({'thing2': ''}, variables)
+    assert result is expected_result
+    mock_check_condition.assert_called_once_with({"thing1": ""}, variables)
 
 
-    ###
-    ### Check conditions
-    ###
-    @patch.object(engine, 'check_condition', return_value=False)
-    def test_check_all_conditions_with_all_false(self, *args):
-        conditions = {'all': [{'thing1': ''}, {'thing2': ''}]}
-        variables = BaseVariables()
-
-        result = engine.check_conditions_recursively(conditions, variables)
-        self.assertEqual(result, False)
-        engine.check_condition.assert_called_once_with({'thing1': ''}, variables)
+def test_do_with_invalid_action() -> None:
+    actions = [{"name": "fakeone"}]
+    err_string = "Action fakeone is not defined in class BaseActions"
+    with pytest.raises(AssertionError, match=err_string):
+        engine.do_actions(actions, BaseActions())
 
 
-    def test_check_all_condition_with_no_items_fails(self):
-        with self.assertRaises(AssertionError):
-            engine.check_conditions_recursively({'all': []}, BaseVariables())
+@pytest.mark.parametrize(
+    ("str_variable_value", "expected"),
+    [
+        ("test_value", True),
+        ("unmatched_test_value", False),
+    ],
+)
+def test_check_condition_with_value(str_variable_value: str, expected: str) -> None:
+    """
+    DOCUMENT ME.
+    """
+    condition = {"name": "name", "operator": "equal_to", "value": "test_value"}
+    with patch.object(
+        engine, "_get_variable_value", return_value=StringType(str_variable_value)
+    ):
+        assert engine.check_condition(condition, BaseVariables()) is expected
 
 
-    @patch.object(engine, 'check_condition', return_value=True)
-    def test_check_any_conditions_with_all_true(self, *args):
-        conditions = {'any': [{'thing1': ''}, {'thing2': ''}]}
-        variables = BaseVariables()
+@pytest.mark.parametrize(
+    ("var1_value", "var2_value", "expected"),
+    [("test_value", "test_value", True), ("test_value", "test_value_2", False)],
+)
+def test_check_condition_with_other_variable_name(
+    var1_value: str, var2_value: str, expected: bool
+) -> None:
+    """
+    DOCUMENT ME.
+    """
+    condition = {"name": "var1", "operator": "equal_to", "other_variable_name": "var2"}
 
-        result = engine.check_conditions_recursively(conditions, variables)
-        self.assertEqual(result, True)
-        engine.check_condition.assert_called_once_with({'thing1': ''}, variables)
+    def get_variable_value_side_effect(_, name: str) -> BaseType:
+        return {"var1": StringType(var1_value), "var2": StringType(var2_value)}[name]
 
-
-    @patch.object(engine, 'check_condition', return_value=False)
-    def test_check_any_conditions_with_all_false(self, *args):
-        conditions = {'any': [{'thing1': ''}, {'thing2': ''}]}
-        variables = BaseVariables()
-
-        result = engine.check_conditions_recursively(conditions, variables)
-        self.assertEqual(result, False)
-        # assert call count and most recent call are as expected
-        self.assertEqual(engine.check_condition.call_count, 2)
-        engine.check_condition.assert_called_with({'thing2': ''}, variables)
-
-
-    def test_check_any_condition_with_no_items_fails(self):
-        with self.assertRaises(AssertionError):
-            engine.check_conditions_recursively({'any': []}, BaseVariables())
+    with patch.object(
+        engine, "_get_variable_value", new=get_variable_value_side_effect
+    ):
+        assert engine.check_condition(condition, BaseVariables()) is expected
 
 
-    def test_check_all_and_any_together(self):
-        conditions = {'any': [], 'all': []}
-        variables = BaseVariables()
-        with self.assertRaises(AssertionError):
-            engine.check_conditions_recursively(conditions, variables)
-
-    @patch.object(engine, 'check_condition')
-    def test_nested_all_and_any(self, *args):
-        conditions = {'all': [
-            {'any': [{'name': 1}, {'name': 2}]},
-            {'name': 3}]}
-        bv = BaseVariables()
-
-        def side_effect(condition, _):
-            return condition['name'] in [2,3]
-        engine.check_condition.side_effect = side_effect
-
-        engine.check_conditions_recursively(conditions, bv)
-        self.assertEqual(engine.check_condition.call_count, 3)
-        engine.check_condition.assert_any_call({'name': 1}, bv)
-        engine.check_condition.assert_any_call({'name': 2}, bv)
-        engine.check_condition.assert_any_call({'name': 3}, bv)
-
-
-    ###
-    ### Operator comparisons
-    ###
-    def test_check_operator_comparison(self):
-        string_type = StringType('yo yo')
-        with patch.object(string_type, 'contains', return_value=True):
-            result = engine._do_operator_comparison(
-                    string_type, 'contains', 'its mocked')
-            self.assertTrue(result)
-            string_type.contains.assert_called_once_with('its mocked')
-
-
-    ###
-    ### Actions
-    ###
-    def test_do_actions(self):
-        actions = [ {'name': 'action1'},
-                    {'name': 'action2',
-                     'params': {'param1': 'foo', 'param2': 10}}]
-        defined_actions = BaseActions()
-        defined_actions.action1 = MagicMock()
-        defined_actions.action2 = MagicMock()
-
-        engine.do_actions(actions, defined_actions)
-
-        defined_actions.action1.assert_called_once_with()
-        defined_actions.action2.assert_called_once_with(param1='foo', param2=10)
-
-    def test_do_with_invalid_action(self):
-        actions = [{'name': 'fakeone'}]
-        err_string = "Action fakeone is not defined in class BaseActions"
-        with self.assertRaisesRegex(AssertionError, err_string):
-            engine.do_actions(actions, BaseActions())
+def test_check_condition_raises_if_both_value_and_other_name_missing() -> None:
+    """
+    DOCUMENT ME.
+    """
+    condition = {
+        "name": "name",
+        "operator": "operator",
+    }
+    with (
+        patch.object(
+            engine, "_get_variable_value", return_value=StringType("test_value")
+        ),
+        pytest.raises(
+            ValueError,
+            match="Condition must have a 'value' or 'other_variable_name' key",
+        ),
+    ):
+        engine.check_condition(condition, BaseVariables())

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,13 +1,21 @@
-from business_rules.operators import (StringType,
-                                      NumericType, BooleanType, SelectType,
-                                      SelectMultipleType)
-
-from unittest import TestCase
-from decimal import Decimal
 import sys
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+from unittest import TestCase
+
+import pytz
+
+from business_rules.operators import (
+    BooleanType,
+    DateTimeType,
+    NumericType,
+    SelectMultipleType,
+    SelectType,
+    StringType,
+)
+
 
 class StringOperatorTests(TestCase):
-
     def test_operator_decorator(self):
         self.assertTrue(StringType("foo").equal_to.is_operator)
 
@@ -48,7 +56,6 @@ class StringOperatorTests(TestCase):
 
 
 class NumericOperatorTests(TestCase):
-
     def test_instantiate(self):
         err_string = "foo is not a valid numeric type"
         with self.assertRaisesRegex(AssertionError, err_string):
@@ -59,10 +66,10 @@ class NumericOperatorTests(TestCase):
         ten_int = 10
         ten_float = 10.0
         if sys.version_info[0] == 2:
-            ten_long = long(10)
+            ten_long = int(10)
         else:
-            ten_long = int(10) # long and int are same in python3
-        ten_var_dec = NumericType(ten_dec) # this should not throw an exception
+            ten_long = int(10)  # long and int are same in python3
+        ten_var_dec = NumericType(ten_dec)  # this should not throw an exception
         ten_var_int = NumericType(ten_int)
         ten_var_float = NumericType(ten_float)
         ten_var_long = NumericType(ten_long)
@@ -76,8 +83,8 @@ class NumericOperatorTests(TestCase):
         self.assertTrue(NumericType(10).equal_to(10.0))
         self.assertTrue(NumericType(10).equal_to(10.000001))
         self.assertTrue(NumericType(10.000001).equal_to(10))
-        self.assertTrue(NumericType(Decimal('10.0')).equal_to(10))
-        self.assertTrue(NumericType(10).equal_to(Decimal('10.0')))
+        self.assertTrue(NumericType(Decimal("10.0")).equal_to(10))
+        self.assertTrue(NumericType(10).equal_to(Decimal("10.0")))
         self.assertFalse(NumericType(10).equal_to(10.00001))
         self.assertFalse(NumericType(10).equal_to(11))
 
@@ -118,7 +125,6 @@ class NumericOperatorTests(TestCase):
 
 
 class BooleanOperatorTests(TestCase):
-
     def test_instantiate(self):
         err_string = "foo is not a valid boolean type"
         with self.assertRaisesRegex(AssertionError, err_string):
@@ -135,7 +141,6 @@ class BooleanOperatorTests(TestCase):
 
 
 class SelectOperatorTests(TestCase):
-
     def test_contains(self):
         self.assertTrue(SelectType([1, 2]).contains(2))
         self.assertFalse(SelectType([1, 2]).contains(3))
@@ -148,45 +153,295 @@ class SelectOperatorTests(TestCase):
 
 
 class SelectMultipleOperatorTests(TestCase):
-
     def test_contains_all(self):
-        self.assertTrue(SelectMultipleType([1, 2]).
-                        contains_all([2, 1]))
-        self.assertFalse(SelectMultipleType([1, 2]).
-                         contains_all([2, 3]))
-        self.assertTrue(SelectMultipleType([1, 2, "a"]).
-                        contains_all([2, 1, "A"]))
+        self.assertTrue(SelectMultipleType([1, 2]).contains_all([2, 1]))
+        self.assertFalse(SelectMultipleType([1, 2]).contains_all([2, 3]))
+        self.assertTrue(SelectMultipleType([1, 2, "a"]).contains_all([2, 1, "A"]))
 
     def test_is_contained_by(self):
-        self.assertTrue(SelectMultipleType([1, 2]).
-                        is_contained_by([2, 1, 3]))
-        self.assertFalse(SelectMultipleType([1, 2]).
-                         is_contained_by([2, 3, 4]))
-        self.assertTrue(SelectMultipleType([1, 2, "a"]).
-                        is_contained_by([2, 1, "A"]))
+        self.assertTrue(SelectMultipleType([1, 2]).is_contained_by([2, 1, 3]))
+        self.assertFalse(SelectMultipleType([1, 2]).is_contained_by([2, 3, 4]))
+        self.assertTrue(SelectMultipleType([1, 2, "a"]).is_contained_by([2, 1, "A"]))
 
     def test_shares_at_least_one_element_with(self):
-        self.assertTrue(SelectMultipleType([1, 2]).
-                        shares_at_least_one_element_with([2, 3]))
-        self.assertFalse(SelectMultipleType([1, 2]).
-                         shares_at_least_one_element_with([4, 3]))
-        self.assertTrue(SelectMultipleType([1, 2, "a"]).
-                        shares_at_least_one_element_with([4, "A"]))
+        self.assertTrue(
+            SelectMultipleType([1, 2]).shares_at_least_one_element_with([2, 3])
+        )
+        self.assertFalse(
+            SelectMultipleType([1, 2]).shares_at_least_one_element_with([4, 3])
+        )
+        self.assertTrue(
+            SelectMultipleType([1, 2, "a"]).shares_at_least_one_element_with([4, "A"])
+        )
 
     def test_shares_exactly_one_element_with(self):
-        self.assertTrue(SelectMultipleType([1, 2]).
-                        shares_exactly_one_element_with([2, 3]))
-        self.assertFalse(SelectMultipleType([1, 2]).
-                         shares_exactly_one_element_with([4, 3]))
-        self.assertTrue(SelectMultipleType([1, 2, "a"]).
-                        shares_exactly_one_element_with([4, "A"]))
-        self.assertFalse(SelectMultipleType([1, 2, 3]).
-                         shares_exactly_one_element_with([2, 3, "a"]))
+        self.assertTrue(
+            SelectMultipleType([1, 2]).shares_exactly_one_element_with([2, 3])
+        )
+        self.assertFalse(
+            SelectMultipleType([1, 2]).shares_exactly_one_element_with([4, 3])
+        )
+        self.assertTrue(
+            SelectMultipleType([1, 2, "a"]).shares_exactly_one_element_with([4, "A"])
+        )
+        self.assertFalse(
+            SelectMultipleType([1, 2, 3]).shares_exactly_one_element_with([2, 3, "a"])
+        )
 
     def test_shares_no_elements_with(self):
-        self.assertTrue(SelectMultipleType([1, 2]).
-                        shares_no_elements_with([4, 3]))
-        self.assertFalse(SelectMultipleType([1, 2]).
-                         shares_no_elements_with([2, 3]))
-        self.assertFalse(SelectMultipleType([1, 2, "a"]).
-                         shares_no_elements_with([4, "A"]))
+        self.assertTrue(SelectMultipleType([1, 2]).shares_no_elements_with([4, 3]))
+        self.assertFalse(SelectMultipleType([1, 2]).shares_no_elements_with([2, 3]))
+        self.assertFalse(
+            SelectMultipleType([1, 2, "a"]).shares_no_elements_with([4, "A"])
+        )
+
+
+class DateTimeOperatorTests(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.TEST_YEAR = 2017
+        self.TEST_MONTH = 1
+        self.TEST_DAY = 16
+        self.TEST_HOUR = 13
+        self.TEST_MINUTE = 55
+        self.TEST_SECOND = 25
+        self.TEST_DATETIME = "{year}-0{month}-{day}T{hour}:{minute}:{second}".format(
+            year=self.TEST_YEAR,
+            month=self.TEST_MONTH,
+            day=self.TEST_DAY,
+            hour=self.TEST_HOUR,
+            minute=self.TEST_MINUTE,
+            second=self.TEST_SECOND,
+        )
+        self.TEST_DATE = "{year}-0{month}-{day}".format(
+            year=self.TEST_YEAR, month=self.TEST_MONTH, day=self.TEST_DAY
+        )
+        self.TEST_DATETIME_OBJ = datetime(
+            self.TEST_YEAR,
+            self.TEST_MONTH,
+            self.TEST_DAY,
+            self.TEST_HOUR,
+            self.TEST_MINUTE,
+            self.TEST_SECOND,
+        )
+        self.TEST_DATE_OBJ = date(self.TEST_YEAR, self.TEST_MONTH, self.TEST_DAY)
+
+        self.TEST_DATETIME_UTC_OBJ = datetime(
+            self.TEST_YEAR,
+            self.TEST_MONTH,
+            self.TEST_DAY,
+            self.TEST_HOUR,
+            self.TEST_MINUTE,
+            self.TEST_SECOND,
+            tzinfo=pytz.UTC,
+        )
+
+        self.datetime_type_date = DateTimeType(self.TEST_DATE)
+        self.datetime_type_datetime = DateTimeType(self.TEST_DATETIME)
+        self.datetime_type_datetime_obj = DateTimeType(self.TEST_DATETIME_OBJ)
+        self.datetime_type_datetime_utc_obj = DateTimeType(self.TEST_DATETIME_UTC_OBJ)
+
+    def test_instantiate(self):
+        err_string = "foo is not a valid datetime type"
+        with self.assertRaisesRegex(AssertionError, err_string):
+            DateTimeType("foo")
+
+    def test_datetime_type_validates_and_cast_datetime(self):
+        result = DateTimeType(self.TEST_DATETIME)
+        self.assertTrue(isinstance(result.value, datetime))
+
+        result = DateTimeType(self.TEST_DATE)
+        self.assertTrue(isinstance(result.value, datetime))
+
+        result = DateTimeType(self.TEST_DATETIME_OBJ)
+        self.assertTrue(isinstance(result.value, datetime))
+
+        result = DateTimeType(self.TEST_DATE_OBJ)
+        self.assertTrue(isinstance(result.value, datetime))
+
+    def test_datetime_equal_to(self):
+        self.assertTrue(self.datetime_type_datetime.equal_to(self.TEST_DATETIME))
+        self.assertTrue(self.datetime_type_datetime.equal_to(self.TEST_DATETIME_OBJ))
+        self.assertTrue(
+            self.datetime_type_datetime.equal_to(self.TEST_DATETIME_UTC_OBJ)
+        )
+
+        self.assertTrue(self.datetime_type_datetime_obj.equal_to(self.TEST_DATETIME))
+        self.assertTrue(
+            self.datetime_type_datetime_obj.equal_to(self.TEST_DATETIME_OBJ)
+        )
+        self.assertTrue(
+            self.datetime_type_datetime_obj.equal_to(self.TEST_DATETIME_UTC_OBJ)
+        )
+
+        self.assertTrue(
+            self.datetime_type_datetime_utc_obj.equal_to(self.TEST_DATETIME)
+        )
+        self.assertTrue(
+            self.datetime_type_datetime_utc_obj.equal_to(self.TEST_DATETIME_OBJ)
+        )
+        self.assertTrue(
+            self.datetime_type_datetime_utc_obj.equal_to(self.TEST_DATETIME_UTC_OBJ)
+        )
+
+        self.assertTrue(self.datetime_type_date.equal_to(self.TEST_DATE))
+        self.assertTrue(self.datetime_type_date.equal_to(self.TEST_DATE_OBJ))
+
+    def test_other_value_not_datetime(self):
+        error_string = "2016-10 is not a valid datetime type"
+        with self.assertRaisesRegex(AssertionError, error_string):
+            DateTimeType(self.TEST_DATE).equal_to("2016-10")
+
+    def datetime_after_than_asserts(self, datetime_type):
+        # type: (DateTimeType) -> None
+        self.assertFalse(datetime_type.after_than(self.TEST_DATETIME))
+        self.assertFalse(datetime_type.after_than(self.TEST_DATETIME_OBJ))
+        self.assertFalse(datetime_type.after_than(self.TEST_DATETIME_UTC_OBJ))
+        self.assertTrue(
+            datetime_type.after_than(self.TEST_DATETIME_OBJ - timedelta(seconds=1))
+        )
+        self.assertTrue(
+            datetime_type.after_than(self.TEST_DATETIME_UTC_OBJ - timedelta(seconds=1))
+        )
+        self.assertFalse(
+            datetime_type.after_than(self.TEST_DATETIME_OBJ + timedelta(seconds=1))
+        )
+        self.assertFalse(
+            datetime_type.after_than(self.TEST_DATETIME_UTC_OBJ + timedelta(seconds=1))
+        )
+
+    def test_datetime_after_than(self):
+        self.datetime_after_than_asserts(self.datetime_type_datetime)
+        self.datetime_after_than_asserts(self.datetime_type_datetime_obj)
+        self.datetime_after_than_asserts(self.datetime_type_datetime_utc_obj)
+
+        self.assertFalse(self.datetime_type_date.after_than(self.TEST_DATE))
+        self.assertFalse(
+            self.datetime_type_date.after_than(
+                self.TEST_DATETIME_OBJ + timedelta(seconds=1)
+            )
+        )
+        self.assertFalse(
+            self.datetime_type_date.after_than(
+                self.TEST_DATETIME_UTC_OBJ + timedelta(seconds=1)
+            )
+        )
+
+    def datetime_after_than_or_equal_to_asserts(self, datetime_type):
+        # type: (DateTimeType) -> None
+        self.assertTrue(datetime_type.after_than_or_equal_to(self.TEST_DATETIME))
+        self.assertTrue(datetime_type.after_than_or_equal_to(self.TEST_DATETIME_OBJ))
+        self.assertTrue(
+            datetime_type.after_than_or_equal_to(self.TEST_DATETIME_UTC_OBJ)
+        )
+        self.assertTrue(
+            datetime_type.after_than_or_equal_to(
+                self.TEST_DATETIME_OBJ - timedelta(seconds=1)
+            )
+        )
+        self.assertFalse(
+            datetime_type.after_than_or_equal_to(
+                self.TEST_DATETIME_OBJ + timedelta(seconds=1)
+            )
+        )
+        self.assertTrue(
+            datetime_type.after_than_or_equal_to(
+                self.TEST_DATETIME_UTC_OBJ - timedelta(seconds=1)
+            )
+        )
+        self.assertFalse(
+            datetime_type.after_than_or_equal_to(
+                self.TEST_DATETIME_UTC_OBJ + timedelta(seconds=1)
+            )
+        )
+
+    def test_datetime_after_than_or_equal_to(self):
+        self.assertTrue(self.datetime_type_date.after_than_or_equal_to(self.TEST_DATE))
+
+        self.datetime_after_than_or_equal_to_asserts(self.datetime_type_datetime)
+        self.datetime_after_than_or_equal_to_asserts(self.datetime_type_datetime_obj)
+        self.datetime_after_than_or_equal_to_asserts(
+            self.datetime_type_datetime_utc_obj
+        )
+
+    def datetime_before_than_asserts(self, datetime_type):
+        # type: (DateTimeType) -> None
+        self.assertFalse(datetime_type.before_than(self.TEST_DATETIME))
+        self.assertFalse(datetime_type.before_than(self.TEST_DATETIME_OBJ))
+        self.assertFalse(datetime_type.before_than(self.TEST_DATETIME_UTC_OBJ))
+        self.assertFalse(
+            datetime_type.before_than(self.TEST_DATETIME_OBJ - timedelta(seconds=1))
+        )
+        self.assertFalse(
+            datetime_type.before_than(self.TEST_DATETIME_UTC_OBJ - timedelta(seconds=1))
+        )
+        self.assertTrue(
+            datetime_type.before_than(self.TEST_DATETIME_OBJ + timedelta(seconds=1))
+        )
+        self.assertTrue(
+            datetime_type.before_than(self.TEST_DATETIME_UTC_OBJ + timedelta(seconds=1))
+        )
+
+    def test_datetime_before_than(self):
+        self.datetime_before_than_asserts(self.datetime_type_datetime)
+        self.datetime_before_than_asserts(self.datetime_type_datetime_obj)
+        self.datetime_before_than_asserts(self.datetime_type_datetime_utc_obj)
+
+        self.assertFalse(self.datetime_type_date.before_than(self.TEST_DATE))
+        self.assertTrue(
+            self.datetime_type_date.before_than(
+                self.TEST_DATETIME_OBJ + timedelta(seconds=1)
+            )
+        )
+        self.assertTrue(
+            self.datetime_type_date.before_than(
+                self.TEST_DATETIME_UTC_OBJ + timedelta(seconds=1)
+            )
+        )
+
+    def datetime_before_than_or_equal_to_asserts(self, datetime_type):
+        # type: (DateTimeType) -> None
+        self.assertTrue(datetime_type.before_than_or_equal_to(self.TEST_DATETIME))
+        self.assertTrue(datetime_type.before_than_or_equal_to(self.TEST_DATETIME_OBJ))
+        self.assertTrue(
+            datetime_type.before_than_or_equal_to(self.TEST_DATETIME_UTC_OBJ)
+        )
+        self.assertFalse(
+            datetime_type.before_than_or_equal_to(
+                self.TEST_DATETIME_OBJ - timedelta(seconds=1)
+            )
+        )
+        self.assertFalse(
+            datetime_type.before_than_or_equal_to(
+                self.TEST_DATETIME_UTC_OBJ - timedelta(seconds=1)
+            )
+        )
+        self.assertTrue(
+            datetime_type.before_than_or_equal_to(
+                self.TEST_DATETIME_OBJ + timedelta(seconds=1)
+            )
+        )
+        self.assertTrue(
+            datetime_type.before_than_or_equal_to(
+                self.TEST_DATETIME_UTC_OBJ + timedelta(seconds=1)
+            )
+        )
+
+    def test_datetime_before_than_or_equal_to(self):
+        self.datetime_before_than_or_equal_to_asserts(self.datetime_type_datetime)
+        self.datetime_before_than_or_equal_to_asserts(self.datetime_type_datetime_obj)
+        self.datetime_before_than_or_equal_to_asserts(
+            self.datetime_type_datetime_utc_obj
+        )
+
+        self.assertTrue(self.datetime_type_date.before_than_or_equal_to(self.TEST_DATE))
+        self.assertTrue(
+            self.datetime_type_date.before_than_or_equal_to(
+                self.TEST_DATETIME_OBJ + timedelta(seconds=1)
+            )
+        )
+        self.assertTrue(
+            self.datetime_type_date.before_than_or_equal_to(
+                self.TEST_DATETIME_UTC_OBJ + timedelta(seconds=1)
+            )
+        )

--- a/tests/test_operators_class.py
+++ b/tests/test_operators_class.py
@@ -1,6 +1,7 @@
 from business_rules.operators import BaseType, type_operator
 from unittest import TestCase
-from mock import MagicMock
+from unittest.mock import MagicMock
+
 
 class OperatorsClassTests(TestCase):
     """ Test methods on classes that inherit from BaseType.


### PR DESCRIPTION
Adds some extensions to the `business-rules` library, including:
- a `not` operator
-   